### PR TITLE
Limit value for empty resultset.

### DIFF
--- a/lib/xapian_db/resultset.rb
+++ b/lib/xapian_db/resultset.rb
@@ -95,6 +95,7 @@ module XapianDb
       @hits         = 0
       @total_pages  = 0
       @current_page = 0
+      @limit_value  = 0
       self
     end
 

--- a/spec/xapian_db/resultset_spec.rb
+++ b/spec/xapian_db/resultset_spec.rb
@@ -56,6 +56,7 @@ describe XapianDb::Resultset do
       resultset.size.should         == 0
       resultset.current_page.should == 0
       resultset.total_pages.should  == 0
+      resultset.limit_value.should  == 0
     end
 
     it "raises an exception if an unsupported option is passed" do


### PR DESCRIPTION
I've just upgraded to 0.5.6 and noticed that some calculations I was doing about the number of results were broken.

The reason: limit_value was returning nil, and I was expecting it to be an integer.

So, being coherent with the other values of the empty resultset, which default to zero, I've added a patch for this.
