### PR TITLE
Using gem 'ruby-progressbar' instead of 'progressbar'

### DIFF
--- a/lib/xapian_db/index_writers/direct_writer.rb
+++ b/lib/xapian_db/index_writers/direct_writer.rb
@@ -64,7 +64,7 @@ module XapianDb
           if opts[:verbose]
             show_progressbar = defined?(ProgressBar)
             puts "reindexing #{obj_count} objects of #{klass}..."
-            pbar = ProgressBar.new("Status", obj_count) if show_progressbar
+            pbar = ProgressBar.create(:title => "Status", :total => obj_count, :format => ' %t %e %B %p%%') if show_progressbar
           end
 
           # Process the objects in batches to reduce the memory footprint
@@ -72,7 +72,7 @@ module XapianDb
           nr_of_batches.times do |batch|
             base_query.all(:offset => batch * BATCH_SIZE, :limit => BATCH_SIZE, :order => klass.order_condition(primary_key)).each do |obj|
               reindex obj, false
-              pbar.inc if show_progressbar
+              pbar.increment if show_progressbar
             end
           end
           XapianDb.database.commit

--- a/spec/xapian_db/index_writers/direct_writer_spec.rb
+++ b/spec/xapian_db/index_writers/direct_writer_spec.rb
@@ -60,7 +60,7 @@ describe XapianDb::IndexWriters::DirectWriter do
     it "accepts a verbose option" do
       # For full coverage the progressbar gem should be installed
       begin
-        require 'progressbar'
+        require 'ruby-progressbar'
       rescue
       end
       XapianDb::IndexWriters::DirectWriter.reindex_class DatamapperObject, :verbose => true

--- a/xapian_db.gemspec
+++ b/xapian_db.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov",        ">= 0.3.7"
   s.add_development_dependency "beanstalk-client", ">= 1.1.0"
   s.add_development_dependency "rake"
-  s.add_development_dependency "progressbar"
+  s.add_development_dependency "ruby-progressbar"
   s.add_development_dependency "resque",           ">= 1.19.0"
   s.add_development_dependency "xapian-ruby",      ">= 1.2.7.1"
 


### PR DESCRIPTION
The gem 'ruby-progressbar' seems more common and therefore I suggest to replace it, since the interface and output is very similar. 
