### PR TITLE
Fix query flags set by config

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -84,8 +84,8 @@ You can override these defaults by placing a config file named 'xapian_db.yml' i
   - language: any iso language code, default: :none (activates spelling corrections, stemmer and stop words if an iso language code ist set)
   - term_min_length: <n>, default: 1 (do not index terms shorter than n)
   - term_splitter_count: <n>, default: 0 (see chapter Term Splitting)
-  - enabled_query_flags: <list of flags, separated by colons>
-  - disabled_query_flags: <list of flags, separated by colons>
+  - enabled_query_flags: <list of flags, separated by commas>
+  - disabled_query_flags: <list of flags, separated by commas>
 
   The following query flags are enabled by default:
 

--- a/lib/xapian_db/railtie.rb
+++ b/lib/xapian_db/railtie.rb
@@ -84,7 +84,9 @@ module XapianDb
 
       if env_config["enabled_query_flags"]
         @enabled_query_flags = []
-        env_config["enabled_query_flags"].split(",").each { |flag_name| @enabled_query_flags << const_get("Xapian::QueryParser::%s" % flag_name.strip) }
+        env_config["enabled_query_flags"].split(",").each do |flag_name|
+          @enabled_query_flags << Xapian::QueryParser.const_get(flag_name.strip)
+        end
       else
         @enabled_query_flags = [ Xapian::QueryParser::FLAG_WILDCARD,
                                  Xapian::QueryParser::FLAG_BOOLEAN,
@@ -95,7 +97,9 @@ module XapianDb
 
       if env_config["disabled_query_flags"]
         @disabled_query_flags = []
-        env_config["disabled_query_flags"].split(",").each { |flag_name| @disabled_query_flags << const_get("Xapian::QueryParser::%s" % flag_name.strip) }
+        env_config["disabled_query_flags"].split(",").each do |flag_name|
+          @disabled_query_flags << Xapian::QueryParser.const_get(flag_name.strip)
+        end
       else
         @disabled_query_flags = []
       end


### PR DESCRIPTION
fix enabled_query_flags and disabled_query_flags being set in config
fix documentation - flags should be separated by commas not colons

Fixes #38
