### PR TITLE
Fixing total_pages in ResultSet

### DIFF
--- a/lib/xapian_db/resultset.rb
+++ b/lib/xapian_db/resultset.rb
@@ -73,7 +73,7 @@ module XapianDb
       raise ArgumentError.new "page #{@page} does not exist" if @hits > 0 && offset >= limit
 
       self.replace result_window.matches.map{|match| decorate(match).document}
-      @total_pages  = (limit / per_page.to_f).ceil
+      @total_pages  = (@hits / per_page.to_f).ceil
       @current_page = page
       @limit_value  = per_page
     end

--- a/spec/xapian_db/resultset_spec.rb
+++ b/spec/xapian_db/resultset_spec.rb
@@ -66,11 +66,11 @@ describe XapianDb::Resultset do
     it "accepts a limit option (as a string or an integer)" do
       @mset.stub!(:matches).and_return(@matches[0..1])
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :limit => "2")
-
       resultset.hits.should         == 3
       resultset.size.should         == 2
       resultset.current_page.should == 1
-      resultset.total_pages.should  == 1
+      resultset.total_pages.should  == 2
+      resultset.total_count.should  == @matches.size
     end
 
     it "accepts a per_page option (as a string or an integer)" do


### PR DESCRIPTION
ResultSet#total_pages is used by will_paginate etc. to determine the length of
the paginator. If I'm not totally wrong, this number has been calculated in the
wrong way, as it was determined by limit / per_page, where limit, when not passed
in as an option, defaults to the database_size. What we actually want is
hits / per_page of course.

Tests are changed accordingly.
