### PR TITLE
Newer Rubies (2.4 onward) use Integer for Integers

### DIFF
--- a/lib/type_codec.rb
+++ b/lib/type_codec.rb
@@ -146,7 +146,7 @@ module XapianDb
       # @return [String] the encoded number
       def self.encode(number)
         case number.class.name
-          when "Fixnum", "Float", "Bignum"
+          when "Fixnum", "Float", "Bignum", "Integer"
             Xapian::sortable_serialise number
           when "BigDecimal"
             Xapian::sortable_serialise number.to_f
@@ -175,7 +175,7 @@ module XapianDb
       def self.encode(number)
         return nil if number.nil?
         case number.class.name
-          when "Fixnum"
+          when "Fixnum", "Integer"
             Xapian::sortable_serialise number
           else
             raise ArgumentError.new "#{number} was expected to be an integer"


### PR DESCRIPTION
See http://nithinbekal.com/posts/ruby-2-4-features/#numbers