### PR TITLE
Change BigDecimal instantation to be compatible with v1.4x and v2.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+##1.3.7.4
+
+Changes:
+
+- Instantiation of a BigDecimal using 'BigDecimal.new()' has been replaced with the new format 'BigDecimal() -- this is compatible with BigDecimal v1.4.x and v2.0.x AND drops support for BigDecimal v1.3.5'
+
+**NOTE: Dropping support for BigDecimal v1.3.5 also drops the support of Ruby 2.2.x and earlier versions of Ruby.**
+
 ##1.3.7.3 (November 30th, 2018)
 
 Changes:

--- a/lib/type_codec.rb
+++ b/lib/type_codec.rb
@@ -160,7 +160,7 @@ module XapianDb
       # @return [BigDecimal] the decoded number
       def self.decode(encoded_number)
         begin
-          BigDecimal.new(Xapian::sortable_unserialise(encoded_number).to_s)
+          BigDecimal(Xapian::sortable_unserialise(encoded_number).to_s)
         rescue TypeError
           raise ArgumentError.new "#{encoded_number} cannot be unserialized"
         end

--- a/xapian_db.gemspec
+++ b/xapian_db.gemspec
@@ -5,7 +5,7 @@ $:.unshift lib unless $:.include?(lib)
 
 Gem::Specification.new do |s|
   s.name         = %q{xapian_db}
-  s.version      = "1.3.7.3"
+  s.version      = "1.3.7.4"
   s.authors      = ["Gernot Kogler"]
   s.license      = 'MIT'
   s.summary      = %q{Ruby library to use a Xapian db as a key/value store with high performance fulltext search}


### PR DESCRIPTION
Support for Ruby 2.7 and beyond and better compatibility with Rails 5.1 and beyond by replacing BigDecimal.new() with BigDecimal() - this new format is valid as of BigDecimal 1.4.x and required for BigDecimal 2.0.x.  

This change however, drops support for BigDecimal v1.3.5 (and thus also support for Ruby 2.2.x).