### PR TITLE
Rollback after destroy issue activerecord

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -61,7 +61,7 @@ You can override these defaults by placing a config file named 'xapian_db.yml' i
 
   # XapianDb configuration
   defaults: &defaults
-    adapter: datamapper # Avaliable adapters: :active_record, :datamapper
+    adapter: datamapper # Available adapters: :active_record, :datamapper
     language: de        # Global language; can be overridden for specific blueprints
     term_min_length: 2  # Ignore single character terms
     enabled_query_flags: FLAG_PHRASE, FLAG_SPELLING_CORRECTION
@@ -226,7 +226,8 @@ If you want to manage the (re)indexing of your objects on your own, turn off aut
     blueprint.autoindex false
   end
 
-This will turn off the auto-reindexing for any object of the configured class. Use XapianDb.reindex(object) to trigger the reindexing logic in your code. Please note that destroying an object will always remove it from the xapian index.
+This will turn off the auto-reindexing for any object of the configured class. Use XapianDb.reindex(object) to trigger the reindexing logic in your code.
+It will also turn off the auto-deletion of the doc, when the object gets destroyed. Use XapianDb.delete_doc_with(object.xapian_id) to trigger deletion logic in your code.
 
 
 Place these configurations either into the corresponding class or - I prefer to have the index configurations outside

--- a/lib/xapian_db/adapters/active_record_adapter.rb
+++ b/lib/xapian_db/adapters/active_record_adapter.rb
@@ -54,11 +54,10 @@ module XapianDb
                    dependency.block.call(self).each{ |model| XapianDb.reindex model, true, changed_attrs: self.previous_changes.keys }
                  end
                end
-             end
 
-             # maybe to be consistent, this should also only happen when autoindex is turned on?
-             after_commit on: :destroy do
-               XapianDb.delete_doc_with(self.xapian_id)
+               after_commit on: :destroy do
+                 XapianDb.delete_doc_with(self.xapian_id)
+               end
              end
 
              # Add a method to reindex all models of this class

--- a/lib/xapian_db/document_blueprint.rb
+++ b/lib/xapian_db/document_blueprint.rb
@@ -352,7 +352,7 @@ module XapianDb
     # @param [Array] args An array of arguments; you can pass a method name, an array of method names
     #   or a method name and an options hash.
     # @param [Block] &block An optional block for complex configurations
-    # Avaliable options:
+    # Available options:
     # - :weight (default: 1) The weight for this indexed value
     # @example Simple index declaration
     #   blueprint.index :name

--- a/spec/xapian_db/adapters/active_record_adapter_spec.rb
+++ b/spec/xapian_db/adapters/active_record_adapter_spec.rb
@@ -52,6 +52,14 @@ describe XapianDb::Adapters::ActiveRecordAdapter do
       expect(ActiveRecordObject.hooks[:after_destroy]).to be_a_kind_of(Proc)
     end
 
+    it "does not add an after destroy hook if autoindexing is turned off for this blueprint" do
+      ActiveRecordObject.reset
+      XapianDb::DocumentBlueprint.setup(:ActiveRecordObject) do |blueprint|
+        blueprint.autoindex false
+      end
+      expect(ActiveRecordObject.hooks[:after_destroy]).not_to be
+    end
+
     it "adds a class method to reindex all objects of a class" do
       expect(ActiveRecordObject).to respond_to(:rebuild_xapian_index)
     end
@@ -142,7 +150,7 @@ describe XapianDb::Adapters::ActiveRecordAdapter do
     end
   end
 
-  describe "the after destroy hook" do
+  describe "after_commit on: :destroy" do
     it "should remove the object from the index" do
       object.save
       expect(XapianDb.search("Kogler").size).to eq(1)

--- a/spec/xapian_db/adapters/datamapper_adapter_spec.rb
+++ b/spec/xapian_db/adapters/datamapper_adapter_spec.rb
@@ -36,8 +36,24 @@ describe XapianDb::Adapters::DatamapperAdapter do
       expect(DatamapperObject.hooks[:after_save]).to be_a_kind_of(Proc)
     end
 
+    it "does not add an after save hook if autoindexing is turned off for this blueprint" do
+      DatamapperObject.reset
+      XapianDb::DocumentBlueprint.setup(:DatamapperObject) do |blueprint|
+        blueprint.autoindex false
+      end
+      expect(DatamapperObject.hooks[:after_save]).not_to be
+    end
+
     it "adds an after destroy hook to the configured class" do
       expect(DatamapperObject.hooks[:after_destroy]).to be_a_kind_of(Proc)
+    end
+
+    it "does not add an after destroy hook if autoindexing is turned off for this blueprint" do
+      DatamapperObject.reset
+      XapianDb::DocumentBlueprint.setup(:DatamapperObject) do |blueprint|
+        blueprint.autoindex false
+      end
+      expect(DatamapperObject.hooks[:after_destroy]).not_to be
     end
 
     it "adds a class method to reindex all objects of a class" do

--- a/spec/xapian_db/index_writers/beanstalk_writer_spec.rb
+++ b/spec/xapian_db/index_writers/beanstalk_writer_spec.rb
@@ -19,7 +19,7 @@ describe XapianDb::IndexWriters::BeanstalkWriter do
   describe ".index(obj, commit=true, changed_attrs: [])" do
     it "puts the index task on the beanstalk queue" do
       changed_attrs = ['name']
-      expect(described_class.beanstalk).to receive(:put).with({task: "index_task", class: object.class.name, id: object.id, changed_attrs: changed_attrs }.to_json)
+      expect(described_class.beanstalk).to receive(:put).with({ task: "index_task", class: object.class.name, id: object.id, changed_attrs: changed_attrs, commit: true }.to_json)
       XapianDb::IndexWriters::BeanstalkWriter.index object, true, changed_attrs: changed_attrs
     end
   end

--- a/xapian_db.gemspec
+++ b/xapian_db.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ruby-progressbar"
   s.add_development_dependency "resque",           ">= 1.19.0"
   s.add_development_dependency "sidekiq",          ">= 2.13.0"
-  s.add_development_dependency "xapian-ruby",      "= 1.2.22"
+  s.add_development_dependency "xapian-ruby",      "= 1.4.17"
   s.add_development_dependency "pry-rails"
   s.add_development_dependency "descendants_tracker"
 


### PR DESCRIPTION
The main-goal of this PR was to allow the Xapian-Index to be consistent after a destroy-action was rolled back. The document should not get deleted when the transaction is rolled back.

This PR will introduce changes to:

* `ActiveRecordAdapter`:
  * `after_commit on: [:create, :update]` and `after_commit on: :destroy` to allow more consistent behaviour in regards to Transaction-Handling when a `destroy` action gets rolled back.
  * avoid automatic deletion of the object from the XapianDB Index if `autoindex` is disabled

* `DatamapperAdapter`:
  * avoid automatic (re)indexing and automatic deletion of the object, if `autoindex` is disabled
  
Also:
  
  * Bump development-dependency for `xapian-ruby` from `1.2.22` to `1.4.17`
  * Update README.rdoc to document changed behaviour