### PR TITLE
fixes a leak of state between threads when working with XapianDb.auto_indexing_disabled {}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.9 (October 26th, 2022)
+
+Fixes:
+
+- `XapianDb.execute_block` now uses `Thread.current[:xapian_db_block_writer]` to store its block-local writer as to avoid leaking into another Thread
+
 ## 1.3.8 (July 19th, 2021)
 
 Fixes:

--- a/spec/xapian_db_spec.rb
+++ b/spec/xapian_db_spec.rb
@@ -455,6 +455,28 @@ describe XapianDb do
         end }.to raise_error "oops"
       end
 
+      describe "thread safety" do
+        it 'still indexes within another thread' do
+          # this thread has auto_indexing disabled
+          # and should not autoindex
+          t1 = Thread.new do
+            XapianDb.auto_indexing_disabled do
+              object.save
+              sleep(1)
+            end
+            # expect(XapianDb.database.size).to eq(0)
+          end
+
+          # this thread should still autoindex
+          t2 = Thread.new do
+             object.save
+             expect(XapianDb.database.size).to eq(1)
+          end
+
+          [t1, t2].map(&:join)
+        end
+      end
+
     end
   end
 end

--- a/xapian_db.gemspec
+++ b/xapian_db.gemspec
@@ -5,7 +5,7 @@ $:.unshift lib unless $:.include?(lib)
 
 Gem::Specification.new do |s|
   s.name         = %q{xapian_db}
-  s.version      = "1.3.8"
+  s.version      = "1.3.9"
   s.authors      = ["Gernot Kogler"]
   s.license      = 'MIT'
   s.summary      = %q{Ruby library to use a Xapian db as a key/value store with high performance fulltext search}


### PR DESCRIPTION
This PR fixes an issue with leaking the block-local writer into another thread, when working with `XapianDb.auto_index_disabled {}`