### PR TITLE
chore: add 'retry' option to SidekiqWorker

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -537,8 +537,10 @@ Install and start redis as described on the {resque github page}[https://github.
     writer:       sidekiq
     sidekiq_queue: my_queue
     set_max_expansion: 100
+    sidekiq_retry: false
 
 If you don't specify a queue name XapianDb will use 'xapian_db' by default.
+Additionally, if you don't provide a 'sidekiq_retry' option, it will default to 'false'.
 
 === 4. Start sidekiq
 

--- a/lib/xapian_db/config.rb
+++ b/lib/xapian_db/config.rb
@@ -61,6 +61,10 @@ module XapianDb
         @config.instance_variable_get("@_set_max_expansion")
       end
 
+      def sidekiq_retry
+        @config.instance_variable_get("@_sidekiq_retry") || false
+      end
+
       def term_splitter_count
         @config.instance_variable_get("@_term_splitter_count") || 0
       end
@@ -78,8 +82,9 @@ module XapianDb
     # DSL methods
     # ---------------------------------------------------------------------------------
 
-    attr_reader :_database, :_adapter, :_writer, :_beanstalk_daemon, :_resque_queue, :_sidekiq_queue, 
-                :_stemmer, :_stopper, :_term_min_length, :_term_splitter_count, :_enabled_query_flags, :_set_max_expansion
+    attr_reader :_database, :_adapter, :_writer, :_beanstalk_daemon, :_resque_queue, :_sidekiq_queue,
+                :_stemmer, :_stopper, :_term_min_length, :_term_splitter_count, :_enabled_query_flags,
+                :_set_max_expansion, :_sidekiq_retry
 
     # Set the global database to use
     # @param [String] path The path to the database. Either apply a file sytem path or :memory
@@ -157,6 +162,12 @@ module XapianDb
     # @param [Integer] value The value to set for the set_max_expansion setting.
     def set_max_expansion(value)
       @_set_max_expansion = value
+    end
+
+    # Set the value for the Sidekiq retry setting.
+    # @param [Boolean, Numeric] value The value to set for the Sidekiq retry setting.
+    def sidekiq_retry(value)
+      @_sidekiq_retry = value
     end
 
     # Set the language.

--- a/lib/xapian_db/index_writers/sidekiq_worker.rb
+++ b/lib/xapian_db/index_writers/sidekiq_worker.rb
@@ -44,6 +44,10 @@ module XapianDb
         def set_max_expansion
           XapianDb::Config.set_max_expansion
         end
+
+        def sidekiq_retry
+          XapianDb::Config.sidekiq_retry
+        end
       end
     end
   end

--- a/lib/xapian_db/index_writers/sidekiq_writer.rb
+++ b/lib/xapian_db/index_writers/sidekiq_writer.rb
@@ -15,37 +15,43 @@ module XapianDb
       end
 
       class << self
-
-        # Update an object in the index
-        # @param [Object] obj An instance of a class with a blueprint configuration
-
         def queue
           XapianDb::Config.sidekiq_queue
         end
 
+        # Update an object in the index
+        # @param [Object] obj An instance of a class with a blueprint configuration
         def index(obj, _commit= true, changed_attrs: [])
-          Sidekiq::Client.enqueue_to(queue, worker_class, 'index',
-                                     {
-                                       class: obj.class.name,
-                                       id: obj.id,
-                                       changed_attrs: changed_attrs
-                                     }.to_json)
+          Sidekiq::Client.push('queue' => queue,
+                               'class' => worker_class,
+                               'args' => ['index', { class: obj.class.name, id: obj.id, changed_attrs: changed_attrs }.to_json],
+                               'retry' => sidekiq_retry)
         end
 
         # Remove an object from the index
         # @param [String] xapian_id The document id
         def delete_doc_with(xapian_id, _commit= true)
-          Sidekiq::Client.enqueue_to(queue, worker_class, 'delete_doc', { xapian_id: xapian_id }.to_json)
+          Sidekiq::Client.push('queue' => queue,
+                               'class' => worker_class,
+                               'args' => ['delete_doc', { xapian_id: xapian_id }.to_json],
+                               'retry' => sidekiq_retry)
         end
 
         # Reindex all objects of a given class
         # @param [Class] klass The class to reindex
         def reindex_class(klass, _options = {})
-          Sidekiq::Client.enqueue_to(queue, worker_class, 'reindex_class', { class: klass.name }.to_json)
+          Sidekiq::Client.push('queue' => queue,
+                               'class' => worker_class,
+                               'args' => ['reindex_class', { class: klass.name }.to_json],
+                               'retry' => sidekiq_retry)
         end
 
         def set_max_expansion
           XapianDb::Config.set_max_expansion
+        end
+
+        def sidekiq_retry
+          XapianDb::Config.sidekiq_retry
         end
 
         def worker_class

--- a/lib/xapian_db/railtie.rb
+++ b/lib/xapian_db/railtie.rb
@@ -59,6 +59,7 @@ module XapianDb
         config.term_min_length @term_min_length
         config.term_splitter_count @term_splitter_count
         config.set_max_expansion @set_max_expansion
+        config.sidekiq_retry @sidekiq_retry
         @enabled_query_flags.each  { |flag| config.enable_query_flag flag }
         @disabled_query_flags.each { |flag| config.disable_query_flag flag }
       end
@@ -87,6 +88,7 @@ module XapianDb
       @enable_phrase_search = env_config["enable_phrase_search"] == true
       @term_splitter_count  = env_config["term_splitter_count"] || 0
       @set_max_expansion    = env_config["set_max_expansion"]
+      @sidekiq_retry        = env_config["sidekiq_retry"]
 
       if env_config["enabled_query_flags"]
         @enabled_query_flags = []

--- a/spec/xapian_db/index_writers/sidekiq_worker_spec.rb
+++ b/spec/xapian_db/index_writers/sidekiq_worker_spec.rb
@@ -24,6 +24,13 @@ describe XapianDb::IndexWriters::SidekiqWorker do
     end
   end
 
+  describe ".sidekiq_retry" do
+    it "returns the retry value specified in the config" do
+      allow(XapianDb::Config).to receive(:sidekiq_retry) { 3 }
+      expect(subject.sidekiq_retry).to eq(3)
+    end
+  end
+
   describe ".index" do
     it "adds an object to the index" do
       obj.save


### PR DESCRIPTION
https://garaiorem.atlassian.net/browse/REM-24036

### Description:

ACs:

1. `sidekiq_retry` is configurable over the `xapian_db.yml`
2. If we configure `sidekiq_retry` it is correctly used in the [gem](https://github.com/gernotkogler/xapian_db/pull/66/files).
3. if we don’t have the `sidekiq_retry` option set in the `xapian_db.yml`, it will set default value to `false`.