### PR TITLE
make set_max_expansion configurable for Xapian

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -536,6 +536,7 @@ Install and start redis as described on the {resque github page}[https://github.
     database:     db/xapian_db/production
     writer:       sidekiq
     sidekiq_queue: my_queue
+    set_max_expansion: 100
 
 If you don't specify a queue name XapianDb will use 'xapian_db' by default.
 

--- a/lib/xapian_db/config.rb
+++ b/lib/xapian_db/config.rb
@@ -57,6 +57,10 @@ module XapianDb
         @config.instance_variable_get("@_term_min_length") || 1
       end
 
+      def set_max_expansion
+        @config.instance_variable_get("@_set_max_expansion")
+      end
+
       def term_splitter_count
         @config.instance_variable_get("@_term_splitter_count") || 0
       end
@@ -75,7 +79,7 @@ module XapianDb
     # ---------------------------------------------------------------------------------
 
     attr_reader :_database, :_adapter, :_writer, :_beanstalk_daemon, :_resque_queue, :_sidekiq_queue, 
-                :_stemmer, :_stopper, :_term_min_length, :_term_splitter_count, :_enabled_query_flags
+                :_stemmer, :_stopper, :_term_min_length, :_term_splitter_count, :_enabled_query_flags, :_set_max_expansion
 
     # Set the global database to use
     # @param [String] path The path to the database. Either apply a file sytem path or :memory
@@ -147,6 +151,12 @@ module XapianDb
     # @param [String] name The name of the sidekiq queue
     def sidekiq_queue(name)
       @_sidekiq_queue = name
+    end
+
+    # Set the value for the max_expansion setting.
+    # @param [Integer] value The value to set for the set_max_expansion setting.
+    def set_max_expansion(value)
+      @_set_max_expansion = value
     end
 
     # Set the language.

--- a/lib/xapian_db/index_writers/sidekiq_worker.rb
+++ b/lib/xapian_db/index_writers/sidekiq_worker.rb
@@ -40,6 +40,10 @@ module XapianDb
           klass = constantize options['class']
           DirectWriter.reindex_class klass, :verbose => false
         end
+
+        def set_max_expansion
+          XapianDb::Config.set_max_expansion
+        end
       end
     end
   end

--- a/lib/xapian_db/index_writers/sidekiq_writer.rb
+++ b/lib/xapian_db/index_writers/sidekiq_writer.rb
@@ -10,6 +10,8 @@ module XapianDb
 
       SidekiqWorker.class_eval do
         include Sidekiq::Worker
+
+        sidekiq_options set_max_expansion: set_max_expansion
       end
 
       class << self
@@ -40,6 +42,10 @@ module XapianDb
         # @param [Class] klass The class to reindex
         def reindex_class(klass, _options = {})
           Sidekiq::Client.enqueue_to(queue, worker_class, 'reindex_class', { class: klass.name }.to_json)
+        end
+
+        def set_max_expansion
+          XapianDb::Config.set_max_expansion
         end
 
         def worker_class

--- a/lib/xapian_db/query_parser.rb
+++ b/lib/xapian_db/query_parser.rb
@@ -32,6 +32,8 @@ module XapianDb
         parser.stemming_strategy = Xapian::QueryParser::STEM_SOME
         parser.stopper           = XapianDb::Config.stopper
       end
+      max_expansion = XapianDb::Config.set_max_expansion
+      parser.set_max_expansion(max_expansion, Xapian::Query::WILDCARD_LIMIT_MOST_FREQUENT) if max_expansion
 
       # Add the searchable prefixes to allow searches by field
       # (like "name:Kogler")

--- a/lib/xapian_db/railtie.rb
+++ b/lib/xapian_db/railtie.rb
@@ -58,6 +58,7 @@ module XapianDb
         config.language @language.try(:to_sym)
         config.term_min_length @term_min_length
         config.term_splitter_count @term_splitter_count
+        config.set_max_expansion @set_max_expansion
         @enabled_query_flags.each  { |flag| config.enable_query_flag flag }
         @disabled_query_flags.each { |flag| config.disable_query_flag flag }
       end
@@ -85,6 +86,7 @@ module XapianDb
       @term_min_length      = env_config["term_min_length"]
       @enable_phrase_search = env_config["enable_phrase_search"] == true
       @term_splitter_count  = env_config["term_splitter_count"] || 0
+      @set_max_expansion    = env_config["set_max_expansion"]
 
       if env_config["enabled_query_flags"]
         @enabled_query_flags = []


### PR DESCRIPTION
https://garaiorem.atlassian.net/browse/REM-24399

**Description:**

ACs:
1. set_max_expansion is configurable over the xapian_db.yml
2. If we configure set_max_expansion it is correctly used in the GEM
3. if we don’t have the set_max_expansion option set in the xapian_db.yml it should not set set_max_expansion