### PR TITLE
feat: add ERB parsing capability for xapian_db.yml

### DIFF
--- a/lib/xapian_db/railtie.rb
+++ b/lib/xapian_db/railtie.rb
@@ -31,9 +31,9 @@ module XapianDb
       config_file_path = "#{Rails.root}/config/xapian_db.yml"
       if File.exist?(config_file_path)
         db_config = if YAML.respond_to?(:unsafe_load_file) # Psych 4.0 way
-                      YAML.unsafe_load_file(config_file_path)
+                      YAML.unsafe_load(ERB.new(File.read(config_file_path)).result)
                     else
-                      YAML.load_file(config_file_path)
+                      YAML.safe_load(ERB.new(File.read(config_file_path)).result, aliases: true)
                     end
         env_config = db_config[Rails.env]
         env_config ? configure_from(env_config) : configure_defaults

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,11 @@ RSpec.configure do |config|
   # instead of true.
   # config.use_transactional_fixtures = true
   config.before(:each) do
+    if defined?(Rails)
+      @original_rails = Rails
+      Object.send(:remove_const, :Rails)
+    end
+
     XapianDb::Adapters::GenericAdapter.unique_key do
       "#{self.class}-#{self.id}"
     end
@@ -45,6 +50,13 @@ RSpec.configure do |config|
       config.enable_query_flag Xapian::QueryParser::FLAG_BOOLEAN_ANY_CASE
       config.enable_query_flag Xapian::QueryParser::FLAG_SPELLING_CORRECTION
       config.disable_query_flag Xapian::QueryParser::FLAG_PHRASE
+    end
+  end
+
+  config.after(:each) do
+    if @original_rails
+      Object.const_set(:Rails, @original_rails)
+      @original_rails = nil
     end
   end
 end

--- a/spec/xapian_db/railtie_spec.rb
+++ b/spec/xapian_db/railtie_spec.rb
@@ -1,0 +1,52 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/../../lib/xapian_db/railtie.rb')
+
+RSpec.describe 'test' do
+  let(:yaml_content_with_erb) do
+    <<-YAML
+      development:
+        adapter: <%= ENV.fetch('XAPIAN_DB_ADAPTER', 'fallback_adapter') %>
+
+      test:
+        adapter: xapian
+    YAML
+  end
+
+  around do |example|
+    Tempfile.open('xapian_db.yml') do |file|
+      file.write(yaml_content_with_erb)
+      file.rewind
+      @config_file_path = file.path
+
+      example.run
+    end
+  end
+
+  context 'when loading adapter from a temporary YAML file with ERB' do
+    it 'loads the generic adapter based on environment variable' do
+      ENV['XAPIAN_DB_ADAPTER'] = 'generic'
+
+      db_config = if YAML.respond_to?(:unsafe_load_file)
+                    YAML.unsafe_load(ERB.new(File.read(@config_file_path)).result)
+                  else
+                    YAML.safe_load(ERB.new(File.read(@config_file_path)).result, aliases: true)
+                  end
+
+      XapianDb::Railtie.configure_from(db_config['development'])
+
+      expect(XapianDb::Railtie.instance_variable_get(:@adapter)).to eq('generic')
+    end
+
+    it 'loads the xapian adapter based on direct value' do
+      db_config = if YAML.respond_to?(:unsafe_load_file)
+                    YAML.unsafe_load(ERB.new(IO.read(@config_file_path)).result)
+                  else
+                    YAML.safe_load(ERB.new(IO.read(@config_file_path)).result, aliases: true)
+                  end
+
+      XapianDb::Railtie.configure_from(db_config['test'])
+
+      expect(XapianDb::Railtie.instance_variable_get(:@adapter)).to eq('xapian')
+    end
+  end
+end

--- a/xapian_db.gemspec
+++ b/xapian_db.gemspec
@@ -5,7 +5,7 @@ $:.unshift lib unless $:.include?(lib)
 
 Gem::Specification.new do |s|
   s.name         = %q{xapian_db}
-  s.version      = "1.3.14"
+  s.version      = "1.3.15"
   s.authors      = ["Gernot Kogler"]
   s.license      = 'MIT'
   s.summary      = %q{Ruby library to use a Xapian db as a key/value store with high performance fulltext search}


### PR DESCRIPTION
At the moment, **xapian_db.yml** cant parse ERB code. As a result we cant define dynamic values in the xapian_db.yml. This PR adds support for ERB code in xapian_db.yml so that we can use ruby code there.