### PR TITLE
chore: fix gh ci for rpsec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,11 +30,6 @@ RSpec.configure do |config|
   # instead of true.
   # config.use_transactional_fixtures = true
   config.before(:each) do
-    if defined?(Rails)
-      @original_rails = Rails
-      Object.send(:remove_const, :Rails)
-    end
-
     XapianDb::Adapters::GenericAdapter.unique_key do
       "#{self.class}-#{self.id}"
     end
@@ -50,13 +45,6 @@ RSpec.configure do |config|
       config.enable_query_flag Xapian::QueryParser::FLAG_BOOLEAN_ANY_CASE
       config.enable_query_flag Xapian::QueryParser::FLAG_SPELLING_CORRECTION
       config.disable_query_flag Xapian::QueryParser::FLAG_PHRASE
-    end
-  end
-
-  config.after(:each) do
-    if @original_rails
-      Object.const_set(:Rails, @original_rails)
-      @original_rails = nil
     end
   end
 end

--- a/spec/xapian_db/railtie_spec.rb
+++ b/spec/xapian_db/railtie_spec.rb
@@ -1,7 +1,22 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../../lib/xapian_db/railtie.rb')
 
 RSpec.describe 'test' do
+  class Railtie
+    def self.configure_from(env_config)
+      @database_path        = env_config["database"] || ":memory:"
+      @adapter              = env_config["adapter"]  || :active_record
+      @writer               = env_config["writer"]   || :direct
+      @beanstalk_daemon_url = env_config["beanstalk_daemon"]
+      @resque_queue         = env_config["resque_queue"]
+      @sidekiq_queue        = env_config["sidekiq_queue"]
+      @language             = env_config["language"]
+      @term_min_length      = env_config["term_min_length"]
+      @enable_phrase_search = env_config["enable_phrase_search"] == true
+      @term_splitter_count  = env_config["term_splitter_count"] || 0
+      @set_max_expansion    = env_config["set_max_expansion"]
+      @sidekiq_retry        = env_config["sidekiq_retry"]
+    end
+  end
   let(:yaml_content_with_erb) do
     <<-YAML
       development:
@@ -32,9 +47,9 @@ RSpec.describe 'test' do
                     YAML.safe_load(ERB.new(File.read(@config_file_path)).result, aliases: true)
                   end
 
-      XapianDb::Railtie.configure_from(db_config['development'])
+      Railtie.configure_from(db_config['development'])
 
-      expect(XapianDb::Railtie.instance_variable_get(:@adapter)).to eq('generic')
+      expect(Railtie.instance_variable_get(:@adapter)).to eq('generic')
     end
 
     it 'loads the xapian adapter based on direct value' do
@@ -44,9 +59,9 @@ RSpec.describe 'test' do
                     YAML.safe_load(ERB.new(IO.read(@config_file_path)).result, aliases: true)
                   end
 
-      XapianDb::Railtie.configure_from(db_config['test'])
+      Railtie.configure_from(db_config['test'])
 
-      expect(XapianDb::Railtie.instance_variable_get(:@adapter)).to eq('xapian')
+      expect(Railtie.instance_variable_get(:@adapter)).to eq('xapian')
     end
   end
 end


### PR DESCRIPTION
Locally the spec passed, because we have Rails env there. But in a gem running in CI, this rails env is missing- that's why it was failing.