### PR TITLE
feat: do not index if there are no changed attributes

### DIFF
--- a/spec/orm_mocks.rb
+++ b/spec/orm_mocks.rb
@@ -101,6 +101,12 @@ end
 # of active_record and has methods to test the helper methods
 class ActiveRecordObject < PersistentObject
 
+  def initialize(*)
+    super
+
+    previous_changes['name'] = @name
+  end
+
   class << self
     def table_name
       self.name
@@ -140,7 +146,12 @@ class ActiveRecordObject < PersistentObject
     end
   end
 
+  def name=(new_name)
+    @previous_changes['name'] = @name
+    @name = new_name
+  end
+
   def previous_changes
-    Hash.new
+    @previous_changes ||= Hash.new
   end
 end

--- a/spec/xapian_db/adapters/active_record_adapter_spec.rb
+++ b/spec/xapian_db/adapters/active_record_adapter_spec.rb
@@ -148,6 +148,15 @@ describe XapianDb::Adapters::ActiveRecordAdapter do
 
       source_object.save
     end
+
+    it "should not reindex the object if no changes have been made" do
+      object.previous_changes.clear
+      expect(object.previous_changes).to be_empty
+
+      expect(XapianDb).not_to receive(:reindex)
+      object.save
+    end
+
   end
 
   describe "after_commit on: :destroy" do

--- a/spec/xapian_db_spec.rb
+++ b/spec/xapian_db_spec.rb
@@ -461,6 +461,7 @@ describe XapianDb do
           # and should not autoindex
           t1 = Thread.new do
             XapianDb.auto_indexing_disabled do
+              object.name = 'changed 1'
               object.save
               sleep(1)
             end
@@ -469,8 +470,9 @@ describe XapianDb do
 
           # this thread should still autoindex
           t2 = Thread.new do
-             object.save
-             expect(XapianDb.database.size).to eq(1)
+            object.name = 'changed 2'
+            object.save
+            expect(XapianDb.database.size).to eq(1)
           end
 
           [t1, t2].map(&:join)


### PR DESCRIPTION
ActiveRecord always triggers the after_commit hook even if the saved model contains no changes.

On my local machines a Sideki queue filled with 10_000 jobs without any changes took 8 minutes to clear.